### PR TITLE
onChange 事件返回 [startRadio, endRadio] 表示滑块起点和终点圈定的数据范围

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ new Slider({
   yAxis: {string},
   start: {string} | {number},
   end: {string} | {number},
+  startRadio?: {number},
+  endRadio?: {number},
   minSpan: {number},
   maxSpan: {number},
   data: {array} | {dataview},
@@ -97,6 +99,23 @@ new Slider({
 (array | dataview)
 
 **必须声明**，数据源。
+
+- `startRadio`
+
+(number)
+
+声明滑动条起始滑块的位置对应的范围边界值，值介于 [0, 1]。
+
+注意：`startRadio` 和 `start` 同时声明时，以 `startRadio` 为准。
+
+- `endRadio`
+
+(number)
+
+声明滑动条结束滑块的位置对应的范围边界值，值介于 [0, 1]。
+
+注意：`endRadio` 和 `end` 同时声明时，以 `endRadio` 为准。
+
 
 - `start`
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ new Slider({
 
   ```js
   onChange: (obj) => {
-    const { startValue, endValue, startText, endText } = obj;
+    const { startValue, endValue, startText, endText, startRadio, endRadio } = obj;
   }
   ```
 
@@ -155,8 +155,11 @@ new Slider({
   * `endValue` 终点滑块当前对应的原始数据值，如果是 `time` 或者 `timeCat` 类型是，该值为时间戳，请注意。
   * `startText` 起点滑块当前的显示文本值
   * `endText` 终点滑块当前的显示文本值
+  * `startRadio` 起点滑块当前对应的范围边界值，值介于 [0, 1]
+  * `endRadio` 终点滑块当前对应的范围边界值，值介于 [0, 1]
 
-> 说明：之所以区分 text 和 value，是因为大部分情况下用户会对数值进行格式化，所以在设置状态量和更新状态量时，需要保证前后数值类型的一致。
+> 说明1：之所以区分 text 和 value，是因为大部分情况下用户会对数值进行格式化，所以在设置状态量和更新状态量时，需要保证前后数值类型的一致。
+> 说明2：若数据并非有序排列，则可以通过 `[startRadio, endRadio]` 获取到滑块起点和终点选中的范围
 
 - `fillerStyle`
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ const { Chart, Util, G, Global } = G2;
 const { Canvas, DomUtil } = G;
 const Range = require('./component/range');
 
+const isNumber = val => typeof val === 'number';
+
 class Slider {
   _initProps() {
     this.height = 26;
@@ -224,15 +226,25 @@ class Slider {
   }
 
   _initRange() {
+    const startRadio = this.startRadio;
+    const endRadio = this.endRadio;
     const start = this.start;
     const end = this.end;
     const scale = this.scale;
     let min = 0;
     let max = 1;
-    if (start) {
+
+    // startRadio 优先级高于 start
+    if (isNumber(startRadio)) {
+      min = startRadio;
+    } else if (start) {
       min = scale.scale(scale.translate(start));
     }
-    if (end) {
+
+    // endRadio 优先级高于 end
+    if (isNumber(endRadio)) {
+      max = endRadio;
+    } else if (end) {
       max = scale.scale(scale.translate(end));
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -331,7 +331,9 @@ class Slider {
         startText: minText,
         endText: maxText,
         startValue: min,
-        endValue: max
+        endValue: max,
+        startRadio: minRatio,
+        endRadio: maxRatio
       });
     }
   }


### PR DESCRIPTION
使用的时候可以直接根据 [startRadio, endRadio] 和 originalData 裁剪无序数据，不用再理会类型，也不用担心数据是不是有序排列的了。

形如：
```
const slider = new Slider({
  container: document.getElementById('slider'),
  data: originalData,
  xAxis: dimension,
  yAxis: 'value',
  startRadio: dataSet.state.startRadio, // 新增
  endRadio: dataSet.state.endRadio,    // 新增 
  onChange: (obj: any): void => {
    const {startRadio, endRadio} = obj;
    dataSet.setState('startRadio', startRadio);
    dataSet.setState('endRadio', endRadio);
  },
});
```

```
// 滚动条设置
dataView.transform({
  type: 'filter',
  callback: (obj: any): boolean => {
    if (_.isNil(dataSet.state.startRadio) || _.isNil(dataSet.state.endRadio)) {
      return true;
    }
    const dataIndex = _.findIndex(originalData, {
      [dimension]: obj[dimension],
      [obj.key]: obj.value,
    });
    const currentRadio = dataIndex / originalData.length;
    return (currentRadio >= dataSet.state.startRadio) && (currentRadio <= dataSet.state.endRadio);
  },
});
```
![g2-plugin-slider-pr](https://user-images.githubusercontent.com/2217416/44564040-a2504200-a793-11e8-850b-5e7ff90f80a1.gif)


https://github.com/antvis/g2/issues/824

