### PR TITLE
修复 start & end 应该始终使用原始日期值

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,8 +337,8 @@ class Slider {
     minTextElement.attr('text', minText);
     maxTextElement.attr('text', maxText);
 
-    this.start = minText;
-    this.end = maxText;
+    this.start = min;
+    this.end = max;
 
     if (this.onChange) {
       this.onChange({


### PR DESCRIPTION
修复 start & end 应该始终使用原始日期值，否则当执行 `forceFit` 时会接收 `Invalid Date in fecha.format` 异常。